### PR TITLE
HibernateでPostgreSQLに接続する際の例外を抑止

### DIFF
--- a/demo/src/main/resources/hibernate.properties
+++ b/demo/src/main/resources/hibernate.properties
@@ -1,0 +1,1 @@
+hibernate.jdbc.lob.non_contextual_creation = true


### PR DESCRIPTION
起動時に例外が出て気持ち悪いので、HibernateでPostgreSQLに接続する際、org.hibernate.engine.jdbc.internal.LobCreatorBuilderImplが出力する例外を抑制するためにチェック処理をスキップする設定を追加しました。

こんな感じでいいのだろうか・・・。